### PR TITLE
Solve error when project_folder has spaces

### DIFF
--- a/ShellExec.py
+++ b/ShellExec.py
@@ -87,7 +87,7 @@ class ShellExec:
 
     if ShellExec.get_setting('context', args) == 'project_folder':
       if 'folder' in sublime.active_window().extract_variables():
-        command = "cd " + sublime.active_window().extract_variables()['folder'] + " && " + command
+        command = "cd '" + sublime.active_window().extract_variables()['folder'] + "' && " + command
     if ShellExec.get_setting('context', args) == 'file_folder':
       if 'file_path' in sublime.active_window().extract_variables():
         command = "cd " + sublime.active_window().extract_variables()['file_path'] + " && " + command


### PR DESCRIPTION
If project_folder has spaces then Shell Exec will fail when trying to
change the current directory to the project folder. For example:

project folder = /Users/myuser/Google Drive/myproject

Will fail because Shell Exec will try to execute:

cd /Users/myuser/Google Drive/myproject && command

And the folder "/Users/myuser/Google" won't be found.

Solve this error by wrapping project_folder between quotes
